### PR TITLE
Plan creation api changes

### DIFF
--- a/src/Console/Commands/CreateStripePlans.php
+++ b/src/Console/Commands/CreateStripePlans.php
@@ -64,9 +64,11 @@ class CreateStripePlans extends Command
             } else {
                 Stripe\Plan::create([
                    'id'                   => $plan->id,
-                   'name'                 => Spark::$details['product'] . ' ' . $plan->name . ' (' .
-                                             Cashier::usesCurrencySymbol() . $plan->price . ' ' . $plan->interval .
-                                             ')',
+                    'product'           => [
+                        'name'                 => Spark::$details['product'] . ' ' . $plan->name . ' (' .
+                            Cashier::usesCurrencySymbol() . $plan->price . ' ' . $plan->interval .
+                            ')',
+                        'statement_descriptor' => Spark::$details['vendor']],
                    'amount'               => $plan->price * 100,
                    'interval'             => str_replace('ly', '', $plan->interval),
                    'currency'             => Cashier::usesCurrency(),


### PR DESCRIPTION
Creating a new plan on stripe now takes plan name and statement_descriptor inside product array